### PR TITLE
Makes the Path to uWSGI's Socket File Configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,6 +166,7 @@ onadata_support_email: "support@{{ onadata_domain }}"
 onadata_wsgi_http: "localhost:9000"
 onadata_pid_socks_dir: "/var/run/{{ onadata_service_name }}"
 onadata_pid_file: "{{ onadata_pid_socks_dir }}/{{ onadata_service_name }}.pid"
+onadata_wsgi_socket: "{{ onadata_pid_socks_dir }}/{{ onadata_service_name }}.sock"
 
 # Pricing library
 onadata_include_pricing: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -55,6 +55,7 @@ dependencies:
       django_wsgi_http: "{{ onadata_wsgi_http }}"
       django_pid_socks_dir: "{{ onadata_pid_socks_dir }}"
       django_pid_file: "{{ onadata_pid_file }}"
+      django_wsgi_socket: "{{ onadata_wsgi_socket }}"
     environment: "{{ onadata_django_env }}"
 
   - role: onaio.ssl-certificate


### PR DESCRIPTION
Makes the path to the uWSGI service's socket file configurable in-case
you would want to refer to that path in a different
deployment/configuration.

Signed-off-by: Jason Rogena <jason@rogena.me>