### PR TITLE
Installs Java Using the onaio.java Role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,9 @@ onadata_system_wide_dependencies:
   - gcc
   - automake
   - libtool
-  - openjdk-11-jre-headless
+onadata_java_version: 11
+onadata_java_package: "openjdk-{{ onadata_java_version }}-jre-headless"
+onadata_java_home: "/usr/lib/jvm/java-{{ onadata_java_version }}-openjdk-amd64"
 onadata_pip_packages:
   - uwsgi
   - django-redis

--- a/examples/load-balanced/requirements.yml
+++ b/examples/load-balanced/requirements.yml
@@ -37,3 +37,7 @@
 - src: kbrebanov.erlang
 
 - src: Stouts.backup
+
+- src: https://github.com/onaio/ansible-java.git
+  name: onaio.java
+  version: 0877b49298034bdf459dfbc9027fd03a983c9e76

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,13 @@ galaxy_info:
     - odk
 
 dependencies:
+  - role: onaio.java
+    java_packages:
+      - "{{ onadata_java_package }}"
+    java_home: "{{ onadata_java_home }}"
+    tags:
+      - java
+
   - role: onaio.django
     vars:
       django_system_user: "{{ onadata_system_user }}"


### PR DESCRIPTION
Use the onaio.java role to install Java which allows configuring
update-alternatives.

Signed-off-by: Jason Rogena <jason@rogena.me>