### PR TITLE
Add a way to configure Celery worker max task limit and task time limit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,13 @@ onadata_celery_app: "onadata.celery"
 onadata_domain: "example.com"
 onadata_celeryd_nodes: "{{ onadata_domain }} export-node publish-xls-form-node google-export xls-exports csv-exports kml-exports osm-exports csv-zip-exports sav-zip-exports external-exports zip-exports osm-exports exports"
 onadata_celeryd_opts: "-O fair --concurrency=8 --autoscale=6,1 -Q:{{ onadata_domain }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xls-exports xls_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports"
+# Task hard time limit in seconds. Celery kills & replaces a worker processing a task that exceeds set time
+# See: https://docs.celeryproject.org/en/stable/userguide/configuration.html#std:setting-task_time_limit
+onadata_celery_task_time_limit:
+# The maximum number of tasks a worker can execute before it's replaced with a new worker
+# See: https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-worker_max_tasks_per_child
+onadata_celery_worker_max_tasks: 100
+
 onadata_django_env:
   CPLUS_INCLUDE_PATH: "/usr/include/gdal"
   C_INCLUDE_PATH: "/usr/include/gdal"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,8 +81,12 @@ onadata_wsgi_module: "onadata.apps.main.wsgi:application"
 onadata_enable_celery: true
 onadata_celery_app: "onadata.celery"
 onadata_domain: "example.com"
+# Maximum amount of memory a worker can consume before it's replaced
+# by a new worker. Value should be in KiB
+# See: https://docs.celeryproject.org/en/stable/userguide/workers.html#max-memory-per-child-setting
+onadata_celery_worker_max_memory: 195312  # 200MB
 onadata_celeryd_nodes: "{{ onadata_domain }} export-node publish-xls-form-node google-export xls-exports csv-exports kml-exports osm-exports csv-zip-exports sav-zip-exports external-exports zip-exports osm-exports exports"
-onadata_celeryd_opts: "-O fair --concurrency=8 --autoscale=6,1 -Q:{{ onadata_domain }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xls-exports xls_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports"
+onadata_celeryd_opts: "-O fair --concurrency=8 --autoscale=6,1 -Q:{{ onadata_domain }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xls-exports xls_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports --max-memory-per-child={{ onadata_celery_worker_max_memory }}"
 # Task hard time limit in seconds. Celery kills & replaces a worker processing a task that exceeds set time
 # See: https://docs.celeryproject.org/en/stable/userguide/configuration.html#std:setting-task_time_limit
 onadata_celery_task_time_limit:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,12 +84,12 @@ onadata_domain: "example.com"
 # Maximum amount of memory a worker can consume before it's replaced
 # by a new worker. Value should be in KiB
 # See: https://docs.celeryproject.org/en/stable/userguide/workers.html#max-memory-per-child-setting
-onadata_celery_worker_max_memory: 195312  # 200MB
+onadata_celery_worker_max_memory: 390625  # 400MB in Kibibyte
 onadata_celeryd_nodes: "{{ onadata_domain }} export-node publish-xls-form-node google-export xls-exports csv-exports kml-exports osm-exports csv-zip-exports sav-zip-exports external-exports zip-exports osm-exports exports"
 onadata_celeryd_opts: "-O fair --concurrency=8 --autoscale=6,1 -Q:{{ onadata_domain }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xls-exports xls_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports --max-memory-per-child={{ onadata_celery_worker_max_memory }}"
 # Task hard time limit in seconds. Celery kills & replaces a worker processing a task that exceeds set time
 # See: https://docs.celeryproject.org/en/stable/userguide/configuration.html#std:setting-task_time_limit
-onadata_celery_task_time_limit:
+onadata_celery_task_time_limit: 3600 # 1 hour
 # The maximum number of tasks a worker can execute before it's replaced with a new worker
 # See: https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-worker_max_tasks_per_child
 onadata_celery_worker_max_tasks: 100

--- a/templates/onadata_checkout_path/onadata/preset/local_settings.py.j2
+++ b/templates/onadata_checkout_path/onadata/preset/local_settings.py.j2
@@ -85,6 +85,12 @@ OAUTH2_PROVIDER['AUTHORIZATION_CODE_EXPIRE_SECONDS'] = 600
 BROKER_TRANSPORT = 'librabbitmq'
 CELERY_BROKER_URL = '{{ onadata_celery_broker_url }}'
 CELERY_RESULT_BACKEND = "{{ onadata_celery_result_backend }}"
+{% if celery_task_time_limit is defined %}
+CELERYD_TIME_LIMIT = "{{ onadata_celery_task_time_limit }}"
+{% endif %}
+{% if celery_worker_max_tasks is defined %}
+CELERYD_MAX_TASKS_PER_CHILD = "{{ onadata_celery_worker_max_tasks }}"
+{% endif %}
 
 {% if onadata_enable_custom_templates %}
 TEMPLATE_OVERRIDE_ROOT_DIR = '{{ onadata_codebase_path }}/onadata/libs/custom_template'


### PR DESCRIPTION
## Changes

- Added new variables:
> `onadata_celery_task_time_limit`: Sets the time limit in seconds that celery should kill & replace workers when reached.
> `onadata_celery_worker_max_tasks`: Sets the maximum number of tasks a worker should complete before being recycled