### PR TITLE
Change ona-tableau-connector filename to onadata-connector

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
   become: true
   become_user: "{{ onadata_system_user }}"
   pip:
-    name: "git+https://github.com/onaio/ona-tableau-connector.git#egg=ona-tableau-connector"
+    name: "git+https://github.com/onaio/ona-tableau-connector.git#egg=onadata-connector"
     virtualenv: "{{ onadata_venv_path }}"
   when: onadata_include_tableau
 


### PR DESCRIPTION
# Changes

- Change `ona-tableau-connector` egg value to `onadata-connector`. _Solves an issue in the latest pip release tied to the metadata of the package_

```
ERROR: Requested onadata-connector from git+https://github.com/onaio/ona-tableau-connector.git#egg=ona-tableau-connector has different nam
e in metadata: 'onadata-connector
```