### PR TITLE
Update IP addresses to and vagrant configs for example deployment

### DIFF
--- a/examples/load-balanced/README.md
+++ b/examples/load-balanced/README.md
@@ -12,23 +12,23 @@ This directory contains Ansible playbooks to deploy services against four Ubuntu
 Here's a list of services that are installed on each of the hosts:
 
 ```
-1. 10.0.0.2
+1. 192.168.56.2
   a. RabbitMQ
   b. Memcached
   c. Monit
   d. collectd
-2. 10.0.0.3 and 10.0.0.4
+2. 192.168.56.3 and 192.168.56.4
   a. Ona Data
   b. NGINX
   c. Monit
   d. PgBouncer
   e. collectd
   f. Logstash
-3. 10.0.0.5
+3. 192.168.56.5
   a. PostgreSQL
   b. Monit
   c. collectd
-4. 10.0.0.6 (optional)
+4. 192.168.56.6 (optional)
   a. Samba
   b. collectd
 ```
@@ -69,20 +69,20 @@ The `deploy-everything.yml` playbook will run the following playbooks:
 
 The `onadata.yml` playbook will set up both Ona Data, NGINX, and Monit in the Ona Data servers.
 
-Once the `deploy-everything.yml` playbook is done running, you can hit either of the Ona Data virtual machines (10.0.0.3 and 10.0.0.4) to access the service. NGINX will handle load balancing the traffic between the hosts.
+Once the `deploy-everything.yml` playbook is done running, you can hit either of the Ona Data virtual machines (192.168.56.3 and 192.168.56.4) to access the service. NGINX will handle load balancing the traffic between the hosts.
 
-To hit 10.0.0.3 using cURL, run:
+To hit 192.168.56.3 using cURL, run:
 
 ```sh
-curl --insecure --header 'Host: example.com' https://10.0.0.3
+curl --insecure --header 'Host: example.com' https://192.168.56.3
 ```
 
 We provide the `--insecure` flag since this example deployment uses a self-signed SSL certificate. In your actual deployment, please don't use a self-signed SSL certificate (unless you really have to).
 
-To access Ona Data on a browser, you will need to set example.com to resolve to either 10.0.0.3 or 10.0.0.4. On MacOS and Linux, set example.com to resolve to 10.0.0.4 by adding the following line to your `/etc/hosts` file:
+To access Ona Data on a browser, you will need to set example.com to resolve to either 192.168.56.3 or 192.168.56.4. On MacOS and Linux, set example.com to resolve to 192.168.56.4 by adding the following line to your `/etc/hosts` file:
 
 ```ini
-10.0.0.4        example.com
+192.168.56.4        example.com
 ```
 
 For Windows, follow [these](https://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/) instructions.
@@ -314,10 +314,10 @@ postgresql_backup_post_actions:
       use_startls: true
     on_error:
       subject: "Ona Data Backup Failed"
-      message: "The last Ona Data database (in host 10.0.0.5) backup failed."
+      message: "The last Ona Data database (in host 192.168.56.5) backup failed."
     on_success:
       subject: "Ona Data Backup Successful"
-      message: "The last Ona Data database (in host 10.0.0.5) backup was successful."
+      message: "The last Ona Data database (in host 192.168.56.5) backup was successful."
 ```
 
 #### 8. Variables to Change
@@ -327,11 +327,11 @@ Consider changing the following variables:
 In [inventory/group_vars/all/vars.yml](./inventory/group_vars/all/vars.yml):
 
 ```yml
-example_postgresql_host: "10.0.0.5" # Set to IP address of your PostgreSQL host
-example_ancillary_host: "10.0.0.2" # Set to IP address of your ancillary host
-example_api_host_0: "10.0.0.3" # Set to IP address of your first Ona Data host
-example_api_host_1: "10.0.0.4" # Set to IP address of your second Ona Data host
-example_samba_ssh_host: "10.0.0.6" # Set to the IP address of your Samba host
+example_postgresql_host: "192.168.56.5" # Set to IP address of your PostgreSQL host
+example_ancillary_host: "192.168.56.2" # Set to IP address of your ancillary host
+example_api_host_0: "192.168.56.3" # Set to IP address of your first Ona Data host
+example_api_host_1: "192.168.56.4" # Set to IP address of your second Ona Data host
+example_samba_ssh_host: "192.168.56.6" # Set to the IP address of your Samba host
 
 example_postgresql_ssh_host: "{{ example_postgresql_host }}"  # Change to Public IP of PostgreSQL host if not on the same subnet.
 example_ancillary_ssh_host: "{{ example_ancillary_host }}"  # Change to Public IP of ancillary host if not on the same subnet.

--- a/examples/load-balanced/inventory/group_vars/all/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/all/vars.yml
@@ -14,8 +14,9 @@ example_api_ssh_host_1: "{{ example_api_host_1 }}"
 
 set_hostname: true
 server_hostname: "{{ inventory_hostname }}"
+ansible_ssh_host: "{{ ansible_host }}"
 
-install_collectd: true
+install_collectd: false
 collectd_scripts_initial:
   - "graphite"
   - "cpu"
@@ -34,6 +35,8 @@ postgresql_onadata_password: "somesecret"
 
 rabbitmq_admin_user: "admin"
 rabbitmq_admin_password: "somesecret"
+rabbitmq_erlang_cookie: YDJHMWIQKFQBCEIDXOXF
+# TODO: Update this
 rabbitmq_port: 5672
 rabbitmq_management_port: 15672
 
@@ -49,7 +52,7 @@ monit_smtp_server: "127.0.0.1"
 monit_smtp_port: "25"
 monit_smtp_username: "root"
 monit_smtp_password: ""
-monit_setup_mode: true
+monit_setup_mode: True
 monit_version: "1:5.*"
 slack_monit_endpoint: ""
 

--- a/examples/load-balanced/inventory/group_vars/all/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/all/vars.yml
@@ -1,11 +1,11 @@
 ---
 ansible_python_interpreter: "/usr/bin/env python3"
 
-example_postgresql_host: "10.0.0.5"
-example_ancillary_host: "10.0.0.2"
-example_api_host_0: "10.0.0.3"
-example_api_host_1: "10.0.0.4"
-example_samba_ssh_host: "10.0.0.6"
+example_postgresql_host: "192.168.56.5"
+example_ancillary_host: "192.168.56.2"
+example_api_host_0: "192.168.56.3"
+example_api_host_1: "192.168.56.4"
+example_samba_ssh_host: "192.168.56.6"
 
 example_postgresql_ssh_host: "{{ example_postgresql_host }}"
 example_ancillary_ssh_host: "{{ example_ancillary_host }}"

--- a/examples/load-balanced/inventory/group_vars/onadata/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/onadata/vars.yml
@@ -1,7 +1,7 @@
 ---
 # Onadata General
 onadata_django_secret_key: "somesecret"
-onadata_version: "v2.0.11"
+onadata_version: "v3.14.0"
 onadata_domain: "example.com"
 onadata_email_admins:
   - name: "Ona Data"
@@ -33,6 +33,7 @@ pgsql_password: "{{ onadata_pgsql_password }}"
 pgsql_host: "{{ example_postgresql_host }}"
 default_pool_size: 50
 pgbouncer_server_tls_ca_content: "{{ lookup('file', 'ssl/postgresql/root.crt') }}"
+pgbouncer_version: "1.*"
 
 # Onadata RabbitMQ
 onadata_rabbitmq_user: "{{ rabbitmq_admin_user }}"
@@ -62,6 +63,7 @@ cifs_mounts:
   
 # NGINX
 nginx_install_method: "package"
+ubuntu_release: "jammy"
 nginx_site_names:
  - "{{ onadata_domain }}"
 nginx_http_site_name: "{{ onadata_domain }}-http"
@@ -140,7 +142,7 @@ pid_file: "{{ onadata_pid_file }}"
 uwsgi_total_memory_limit: "3072"
 
 # Logstash
-install_logstash: true
+install_logstash: false
 logstash_major_ver: "7.x"
 logstash_minor_ver: "1:7.*"
 logstash_gelf_server: 127.0.0.1

--- a/examples/load-balanced/inventory/group_vars/onadata/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/onadata/vars.yml
@@ -1,7 +1,7 @@
 ---
 # Onadata General
 onadata_django_secret_key: "somesecret"
-onadata_version: "v3.14.2"
+onadata_version: "v4.1.0"
 onadata_domain: "example.com"
 onadata_email_admins:
   - name: "Ona Data"
@@ -20,9 +20,7 @@ onadata_pid_socks_dir: "/var/run/{{ onadata_service_name }}"
 onadata_pid_file: "{{ onadata_pid_socks_dir }}/{{ onadata_service_name }}.pid"
 
 # Onadata celery
-onadata_celeryd_nodes: "{{ nginx_server_name }} export-node publish-xls-form-node google-export xlsx-exports csv-exports kml-exports osm-exports csv-zip-exports sav-zip-exports external-exports zip-exports osm-exports exports post-processing csv-imports delete-xforms messaging"
-onadata_celeryd_opts: "-O fair --concurrency=4 --autoscale=6,2 -Q:{{ nginx_server_name }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xlsx-exports xlsx_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports -Q:csv-imports csv_imports -Q:delete-xforms delete_xforms -Q:messaging messaging"
-
+nginx_server_name: "example.com"
 # How long (in seconds or timedelta) a celery task should be considered valid
 # see http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-result_expires
 onadata_celery_task_result_expires: 3600

--- a/examples/load-balanced/inventory/group_vars/onadata/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/onadata/vars.yml
@@ -1,11 +1,11 @@
 ---
 # Onadata General
 onadata_django_secret_key: "somesecret"
-onadata_version: "v3.14.0"
+onadata_version: "v3.14.2"
 onadata_domain: "example.com"
 onadata_email_admins:
   - name: "Ona Data"
-    email: "admin@example.com"
+    email: "admin@example.com" # TODO: update this
 onadata_support_email: "support@example.com"
 onadata_static_path: "{{ onadata_checkout_path }}/onadata/static/"
 onadata_codebase_path: "{{ onadata_system_user_home }}/app"
@@ -18,6 +18,53 @@ onadata_wsgi_bind_port: 9000
 onadata_service_name: "{{ onadata_system_user }}"
 onadata_pid_socks_dir: "/var/run/{{ onadata_service_name }}"
 onadata_pid_file: "{{ onadata_pid_socks_dir }}/{{ onadata_service_name }}.pid"
+
+# Onadata celery
+onadata_celeryd_nodes: "{{ nginx_server_name }} export-node publish-xls-form-node google-export xlsx-exports csv-exports kml-exports osm-exports csv-zip-exports sav-zip-exports external-exports zip-exports osm-exports exports post-processing csv-imports delete-xforms messaging"
+onadata_celeryd_opts: "-O fair --concurrency=4 --autoscale=6,2 -Q:{{ nginx_server_name }} celery -Q:export-node exports -Q:publish-xls-form-node publish_xlsform -Q:google-export google_export -Q:xlsx-exports xlsx_exports -Q:csv-exports csv_exports -Q:kml-exports kml_exports -Q:osm-exports osm-exports -Q:csv-zip-exports csv_zip_exports -Q:sav-zip-exports sav_zip_exports -Q:external-exports external_exports -Q:zip-exports zip_exports -Q:osm-exports osm_exports -Q:exports exports -Q:csv-imports csv_imports -Q:delete-xforms delete_xforms -Q:messaging messaging"
+
+# How long (in seconds or timedelta) a celery task should be considered valid
+# see http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-result_expires
+onadata_celery_task_result_expires: 3600
+
+# The schedule for the Celery Beat task that marks export tasks as expired
+onadata_celery_beat_mark_exports_expired_schedule: "crontab(hour='*', minute='0')"
+
+# The schedule for the Celery Beat task that deletes export tasks that have been marked as expired
+onadata_celery_beat_delete_expired_exports_schedule: "crontab(hour='*', minute='10')"
+
+# The schedule for running the celery.backend_cleanup task (responsible for cleaning expired task results)
+# see http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-result_expires
+onadata_celery_backend_cleanup_schedule: "crontab(hour='*', minute='30')"
+onadata_celery_task_route:
+  messaging:
+    - "onadata.apps.messaging.tasks.call_backend_async"
+  delete_xforms:
+    - "onadata.apps.api.tasks.delete_xform_async"
+  csv_imports:
+    - "onadata.libs.utils.csv_import.submit_csv_async"
+  publish_xlsform:
+    - "onadata.apps.api.tasks.publish_xlsform_async"
+  xlsx_exports:
+    - "onadata.apps.viewer.tasks.create_xlsx_export"
+  csv_exports:
+    - "onadata.apps.viewer.tasks.create_csv_export"
+  kml_exports:
+    - "onadata.apps.viewer.tasks.create_kml_export"
+  osm_exports:
+    - "onadata.apps.viewer.tasks.create_osm_export"
+  zip_exports:
+    - "onadata.apps.viewer.tasks.create_zip_export"
+    - "onadata.apps.viewer.tasks.create_csv_zip_export"
+  sav_zip_exports:
+    - "onadata.apps.viewer.tasks.create_sav_zip_export"
+  external_exports:
+    - "onadata.apps.viewer.tasks.create_external_export"
+  google_export:
+    - "google_export.tasks.call_google_sheet_service"
+    - "google_export.tasks.sync_update_google_sheets"
+    - "google_export.tasks.sync_delete_google_sheets"
+    - "onadata.apps.viewer.tasks.create_google_sheet_export"
 
 # Onadata PostgreSQL
 onadata_pgsql_host: "127.0.0.1"
@@ -60,12 +107,12 @@ cifs_mount_options: "uid=onadata,gid=onadata,username={{ cifs_mount_user }},pass
 cifs_mount_path: "/home/onadata"
 cifs_mounts:
   - "{{ samba_onadata_share }}"
-  
+
 # NGINX
 nginx_install_method: "package"
 ubuntu_release: "jammy"
 nginx_site_names:
- - "{{ onadata_domain }}"
+  - "{{ onadata_domain }}"
 nginx_http_site_name: "{{ onadata_domain }}-http"
 nginx_https_site_name: "{{ onadata_domain }}-https"
 nginx_enabled_sites:
@@ -115,7 +162,7 @@ nginx_sites:
         proxy_next_upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 nginx_access_logs:
   - name: "timed_combined"
-    format: "'$http_x_forwarded_for - $remote_user [$time_local]  \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" $request_time $upstream_response_time $gzip_ratio $request_length'"
+    format: '''$http_x_forwarded_for - $remote_user [$time_local]  "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time $upstream_response_time $gzip_ratio $request_length'''
     options: null
     filename: "access.log"
 nginx_onadata_loadbalancer_name: onadata
@@ -154,22 +201,22 @@ logstash_plugins:
   - name: logstash-output-gelf
     state: present
 logstash_custom_outputs:
-  - output: 'gelf'
+  - output: "gelf"
     lines:
       - 'host => "{{ logstash_gelf_server }}"'
       - 'port => "{{ logstash_gelf_port }}"'
       - 'sender => "{{ onadata_domain }}"'
 logstash_custom_inputs:
-  - input: 'file'
+  - input: "file"
     lines:
       - 'path => ["/var/log/nginx/{{ onadata_domain }}-https-ssl-access.log"]'
       - 'start_position => "end"'
-      - 'add_field => {'
-      - '  ssl => true'
-      - '  nginx_access => true'
-      - '  from_nginx => true'
+      - "add_field => {"
+      - "  ssl => true"
+      - "  nginx_access => true"
+      - "  from_nginx => true"
       - '  from_host => "%{host}"'
       - '  from_domain => "{{ onadata_domain }}"'
-      - '  from_onadata => true'
+      - "  from_onadata => true"
       - '  git_version => "{{ onadata_version }}"'
-      - '}'
+      - "}"

--- a/examples/load-balanced/inventory/group_vars/postgresql/vars.yml
+++ b/examples/load-balanced/inventory/group_vars/postgresql/vars.yml
@@ -1,6 +1,8 @@
 ---
 # PostgreSQL General
-postgresql_version: 10
+postgresql_version: 15
+monit_postgresql_version: 15
+monit_postgresql_listen_addresses: "{{ postgresql_listen_addresses }}"
 postgresql_users:
   - name: "{{ postgresql_onadata_user }}"
     pass: "{{ postgresql_onadata_password }}"
@@ -23,7 +25,7 @@ postgresql_pg_hba_md5_hosts:
   - "{{ example_postgresql_host }}/32"
   - "{{ example_api_host_0 }}/32"
   - "{{ example_api_host_1 }}/32"
-postgresql_ext_postgis_version: "2.5"
+postgresql_ext_postgis_version: "3"
 postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
@@ -65,6 +67,8 @@ cifs_mount_options: "uid=postgres,gid=postgres,username={{ cifs_mount_user }},pa
 cifs_mount_path: "/var/lib/postgresql"
 cifs_mounts:
   - "{{ samba_backups_share }}"
+
+monit_setup_mode: True
 
 # Monit
 monit_scripts:

--- a/examples/load-balanced/inventory/group_vars/rabbitmq/var.yml
+++ b/examples/load-balanced/inventory/group_vars/rabbitmq/var.yml
@@ -1,4 +1,6 @@
 ---
+rabbitmq_user: "{{ rabbitmq_admin_user }}"
+rabbitmq_ulimit_open_files: 512
 rabbitmq_users:
   - user: "{{ rabbitmq_admin_user }}"
     password: "{{ rabbitmq_admin_password }}"
@@ -10,6 +12,3 @@ rabbitmq_users:
 rabbitmq_plugins:
   - rabbitmq_management
   - rabbitmq_top
-rabbitmq_ulimit_open_files: "60000"
-
-erlang_version: 20.3

--- a/examples/load-balanced/inventory/host_vars/postgres-host/vars.yml
+++ b/examples/load-balanced/inventory/host_vars/postgres-host/vars.yml
@@ -1,3 +1,13 @@
 ---
 ansible_user: "ubuntu"
 ansible_host: "{{ example_postgresql_ssh_host }}"
+
+# Monit
+monit_scripts:
+  - email
+  - email_smtp
+  - monit
+  - openssh-server
+  - rsyslog
+  - system
+  - postgres

--- a/examples/load-balanced/onadata.yml
+++ b/examples/load-balanced/onadata.yml
@@ -25,6 +25,7 @@
         - cifs
     - role: onaio.nginx
       become: true
+      nginx: "nginx=1.26.*"
       tags:
         - nginx
     - role: onaio.monit

--- a/examples/load-balanced/onadata.yml
+++ b/examples/load-balanced/onadata.yml
@@ -7,6 +7,9 @@
     - include_tasks: tasks/python3-ubuntu.yml
     - name: Setup Ansible
       setup:
+    - name: Install acl
+      become: true
+      shell: apt install acl
   roles:
     - role: onaio.pgbouncer
       become: true

--- a/examples/load-balanced/postgresql.yml
+++ b/examples/load-balanced/postgresql.yml
@@ -5,6 +5,9 @@
     - include_tasks: tasks/python3-ubuntu.yml
     - name: Setup Ansible
       setup:
+    - name: Install acl
+      become: true
+      shell: apt install acl
   roles:
     - role: onaio.postgresql
       become: true

--- a/examples/load-balanced/rabbitmq.yml
+++ b/examples/load-balanced/rabbitmq.yml
@@ -5,11 +5,11 @@
     - include_tasks: tasks/python3-ubuntu.yml
     - name: Setup Ansible
       setup:
-  roles:
-    - role: kbrebanov.erlang
+  post_tasks:
+    - name: Verify that rabbitmq user is created as expected
       become: true
-      tags:
-        - erlang
+      shell: rabbitmqctl authenticate_user {{ rabbitmq_admin_user }} {{ rabbitmq_admin_password }}
+  roles:
     - role: onaio.rabbitmq
       become: true
       tags:

--- a/examples/load-balanced/requirements.yml
+++ b/examples/load-balanced/requirements.yml
@@ -12,7 +12,7 @@
 - src: https://github.com/onaio/ansible-nginx.git
   name: onaio.nginx
   scm: git
-  version: a962b5418e092530a0c293b111d482ce1d8f877e
+  version: 35219bb0fbc358017db30ef7a258b25b5e84ab79
 
 - src: https://github.com/onaio/ansible-gpg-import.git
   name: onaio.gpg-import
@@ -22,12 +22,12 @@
 - src: https://github.com/onaio/ansible-postgresql.git
   name: onaio.postgresql
   scm: git
-  version: e58bdd852654452be08427d181d678ad3ff67ab8
+  version: 762e90937d165fca6155dc1d38d60212443eb79e
 
 - src: https://github.com/onaio/ansible-onadata.git
   name: onaio.onadata
   scm: git
-  version: 8e0d32e181c8e4570a1ef7de3fc32c218d7352d4
+  version: e4ae4bcc8dd7715140fcb7f30aadaeba6188fe74
 
 - src: https://github.com/onaio/ansible-rabbitmq.git
   name: onaio.rabbitmq
@@ -40,12 +40,12 @@
   version: a7412bfc3078dacbf47840bceee4e121e82e54ec
 
 - src: geerlingguy.memcached
-  version: 1.1.0
+  version: 2.2.0
 
 - src: https://github.com/onaio/ansible-backup.git
   name: onaio.backup
   scm: git
-  version: 9e5d3e00ec15fff0fc916b8cbc224731f28dde05
+  version: ea06304f56d2c864336b0c39391c720940065169
 
 - src: https://github.com/onaio/ansible-java.git
   name: onaio.java

--- a/examples/load-balanced/requirements.yml
+++ b/examples/load-balanced/requirements.yml
@@ -2,17 +2,17 @@
 - src: https://github.com/onaio/ansible-django.git
   name: onaio.django
   scm: git
-  version: afc3de8917d0e0abc6c54d8a531219357522fd52
+  version: 58f95973baafab22d41bd14d96dd94f3a1d2cc68
 
 - src: https://github.com/onaio/ansible-ssl-certificate.git
   name: onaio.ssl-certificate
   scm: git
-  version: f382d69ae6a8c733ddac183f0d0b3dcd8be51cfd
+  version: 5c33a9ddf298d6a20914c2b7d9e2ecb2d1c7a763
 
 - src: https://github.com/onaio/ansible-nginx.git
   name: onaio.nginx
   scm: git
-  version: 82be3d4638b1422f1ceaffe6658bb3373da6c745
+  version: a962b5418e092530a0c293b111d482ce1d8f877e
 
 - src: https://github.com/onaio/ansible-gpg-import.git
   name: onaio.gpg-import
@@ -22,43 +22,40 @@
 - src: https://github.com/onaio/ansible-postgresql.git
   name: onaio.postgresql
   scm: git
-  version: a630676e0e13574a53cfa26ca326e4f4d06d30b1
+  version: e58bdd852654452be08427d181d678ad3ff67ab8
 
 - src: https://github.com/onaio/ansible-onadata.git
   name: onaio.onadata
   scm: git
-  version: 9a59d140b0a4c3721a94e4793e05ccb92910bca4
+  version: 8e0d32e181c8e4570a1ef7de3fc32c218d7352d4
 
 - src: https://github.com/onaio/ansible-rabbitmq.git
   name: onaio.rabbitmq
   scm: git
-  version: 95ca24c2553954e224d6a7808c81624a1f5a67c1
+  version: update-new-repository
 
 - src: https://github.com/onaio/ansible-monit.git
   name: onaio.monit
   scm: git
-  version: 6dc374e7be8f40eb51eef95ab1dff029d9e13674
+  version: a7412bfc3078dacbf47840bceee4e121e82e54ec
 
 - src: geerlingguy.memcached
   version: 1.1.0
 
-- src: kbrebanov.erlang
-  version: v3.0.0
-
 - src: https://github.com/onaio/ansible-backup.git
   name: onaio.backup
   scm: git
-  version: 8b385675aa6980699719a7f940e98e68d3ba37f4
+  version: 9e5d3e00ec15fff0fc916b8cbc224731f28dde05
 
 - src: https://github.com/onaio/ansible-java.git
   name: onaio.java
   scm: git
-  version: 0877b49298034bdf459dfbc9027fd03a983c9e76
+  version: 6551af3cd0b499cbc34c87552b77bbc5365563b4
 
 - src: https://github.com/onaio/ansible-pgbouncer.git
   name: onaio.pgbouncer
   scm: git
-  version: 88d5e8dfc403d9de3c7954d426823546ff33a1cb
+  version: 7e7d54d206874bfabe6a8ed1140f7906b8e7e1ee
 
 - src: https://github.com/onaio/ansible-collectd.git
   name: onaio.collectd
@@ -75,14 +72,16 @@
   scm: git
   version: dd5c5ee9bd5d45b5e5f6186b5e63e4eba486d8e5
 
-- src: ANXS.postgresql
-  version: v1.11.1
+- src: https://github.com/ANXS/postgresql.git
+  name: ANXS.postgresql
+  scm: git
+  version: 2697f93749651d1a3aaac2d5cd8b50fa51d978f3
 
 - src: bertvv.samba
   version: v2.7.1
 
 - src: arillso.users
-  version: 1.4.5
+  version: 1.4.6
 
 - src: https://github.com/onaio/ansible-systemd-cifs-mount.git
   name: onaio.systemd_cifs_mount

--- a/examples/load-balanced/vagrant/Vagrantfile
+++ b/examples/load-balanced/vagrant/Vagrantfile
@@ -1,8 +1,11 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = 'ubuntu/bionic64'
+  config.vm.box = 'bento/ubuntu-22.04'
 
   config.vm.provision "shell", inline: "echo Granting generated SSH key to ubuntu user"
   config.vm.provision "file", source: "~/.ssh/id_ed25519.pub", destination: "/tmp/ubuntu_authorized_keys"
+  config.vm.provision "shell", inline: "sudo useradd -m ubuntu -s /bin/bash"
+  config.vm.provision "shell", inline: "sudo mkdir -p /home/ubuntu/.ssh"
+  config.vm.provision "shell", inline: "sudo chown -R ubuntu:ubuntu /home/ubuntu/.ssh"
   config.vm.provision "shell", inline: "sudo tee -a /home/ubuntu/.ssh/authorized_keys < /tmp/ubuntu_authorized_keys"
   config.vm.provision "shell", inline: "sudo chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys"
 

--- a/examples/load-balanced/vagrant/hosts/API0.rb
+++ b/examples/load-balanced/vagrant/hosts/API0.rb
@@ -2,10 +2,10 @@ Vagrant.configure("2") do |config|
   config.vm.define "api0" do |api0|
     api0.vm.provider :virtualbox do |vb|
       vb.name = "ansible-onadata-lb-api0"
-      vb.memory = 4096
-      vb.cpus = 2
+      vb.memory = 1024
+      vb.cpus = 1
     end
 
-    api0.vm.network "private_network", ip: "10.0.0.3"
+    api0.vm.network "private_network", ip: "192.168.56.3"
   end
 end

--- a/examples/load-balanced/vagrant/hosts/API1.rb
+++ b/examples/load-balanced/vagrant/hosts/API1.rb
@@ -2,10 +2,10 @@ Vagrant.configure("2") do |config|
   config.vm.define "api1" do |api1|
     api1.vm.provider :virtualbox do |vb|
       vb.name = "ansible-onadata-lb-api1"
-      vb.memory = 4096
-      vb.cpus = 2
+      vb.memory = 1024
+      vb.cpus = 1
     end
 
-    api1.vm.network "private_network", ip: "10.0.0.4"
+    api1.vm.network "private_network", ip: "192.168.56.4"
   end
 end

--- a/examples/load-balanced/vagrant/hosts/Ancillary.rb
+++ b/examples/load-balanced/vagrant/hosts/Ancillary.rb
@@ -6,6 +6,6 @@ Vagrant.configure("2") do |config|
       vb.cpus = 1
     end
 
-    anc.vm.network "private_network", ip: "10.0.0.2"
+    anc.vm.network "private_network", ip: "192.168.56.2"
   end
 end

--- a/examples/load-balanced/vagrant/hosts/PostgreSQL.rb
+++ b/examples/load-balanced/vagrant/hosts/PostgreSQL.rb
@@ -6,6 +6,6 @@ Vagrant.configure("2") do |config|
       vb.cpus = 1
     end
 
-    postgres.vm.network "private_network", ip: "10.0.0.5"
+    postgres.vm.network "private_network", ip: "192.168.56.5"
   end
 end

--- a/examples/load-balanced/vagrant/hosts/Samba.rb
+++ b/examples/load-balanced/vagrant/hosts/Samba.rb
@@ -2,10 +2,10 @@ Vagrant.configure("2") do |config|
   config.vm.define "samba" do |samba|
     samba.vm.provider :virtualbox do |vb|
       vb.name = "ansible-onadata-lb-samba"
-      vb.memory = 512
+      vb.memory = 1024
       vb.cpus = 1
     end
 
-    samba.vm.network "private_network", ip: "10.0.0.6"
+    samba.vm.network "private_network", ip: "192.168.56.6"
   end
 end

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -2,11 +2,12 @@
 - src: https://github.com/onaio/ansible-django.git
   name: onaio.django
   scm: git
-  version: a6a19b393de166d1cbbd9fb3c7cdf3a6c1c058dd
+  version: 58f95973baafab22d41bd14d96dd94f3a1d2cc68
 
 - src: https://github.com/onaio/ansible-ssl-certificate.git
   name: onaio.ssl-certificate
   scm: git
+  version: 5c33a9ddf298d6a20914c2b7d9e2ecb2d1c7a763
 
 - src: https://github.com/onaio/ansible-java.git
   name: onaio.java


### PR DESCRIPTION
## Upgrade Plan
- [x] Ensure the ansible roles and inventories for the following services are updated before date of production deployment
    - [x] Onadata
    - [x] Pgbouncer
    - [x] Nginx
    - [x] PostgreSQL
    - [x] RabbitMQ
    - [x] Memcached
- [x] Notify the QA team that an upgrade will be happening and a QA engineer will be needed after the upgrade is done
- [ ] [Optional] Take a snapshot of the servers if possible before performing any upgrades
- [x] Stop all traffic to the OnaData servers; Ensure the API is not receiving any new submissions during the upgrade.
    - [x] Stop the service by running `systemctl stop onadata.service celery*`
    - [x] If the monit service is running, stop the service by running `systemctl stop monit` to avoid restarting the onadata service during the upgrade
- [x] Backup existing configurations i.e onadata application settings i.e `local_settings.py`, uwsgi configs i.e `uwsgi.ini`,  nginx configs and pgbouncer
- [x] Take a full backup of the PostgreSQL Database using `pg_dump`
   `pg_dump --dbname onadata -h <db host> -U onadata --schema-only > schema-dump.sql` and `pg_dump --dbname onadata -h  <db host> -U onadata  > full-dump.sql`
    - [x] Ensure Backup/Database Dump file is present in external storage location
    - [x] [Optional] Ensure to have a dump of the database schema
- [x] [Optional] Run the `sudo apt-get dist-upgrade` command to update currently installed softwares
- [x] Upgrade the servers from 18.04 to Ubuntu 22.04 via `do-release-upgrade`; Note: Do not restart the service when prompted to restart.
    - [x] Restart the `ssh` and `sshd` services; Ensure that they are running as expected
    - [x] Try to connect from a separate terminal
    - [x] Restart the virtual machine
    - [x] Verify that we still have connection to the server
    - [x] Verify that the release version is 22.04; `lsb_release -a`
 - [x] Upgrade PostgreSQL version from 10.23 to 13.12
     - [x] Confirm that it's possible to restore the PostgreSQL backups
     - [x] Ensure PostgreSQL service is running after the OS update
     - [x] Ensure that the DB schema has the correct DDL after the upgrade i.e indexes and constraints
 - [x] Deploy OnaData v3.14.2
    - [x] Ansible deploy v3.14.2
        - [x]  `ansible-playbook -i inventory deploy-everything.yml --limit onadata`
    - [x] Verify the migrations that need to be run: `python manage.py showmigrations`
    - [x] Run migrations: `python manage.py migrate`
    - [x] Check state of the service: `systemctl status onadata.service celeryd-onadata celerybeat-onadata`
    - [x] Verify that you can still access some of the database entries:
            ```python
            from onadata.apps.logger.models import Instance
            Instance.objects.first()
            ```
    - [x] Check Nginx logs and try to access the site to verify that the service is up and running
- [x] Upgrade RabbitMQ to 3.10.7
     - [x] Ansible deploy RabbitMQ v3.10.7 `ansible-playbook -i inventory deploy-everything.yml --limit rabbitmq`
    - [x] Ensure that the rabbitmq service is running. Run `sudo systemctl status rabbitmq-server` & `sudo rabbitmqctl status`
    - [x] Verify that the OnaData admin user has been created and has the correct tags with correct credentials. Run `rabbitmqctl list_users`. Expected entry: `admin [administrator]`
    - [x] Ensure that onadata is able to connect to RabbitMQ and exports are working fine
- [x] Deploy Nginx v1.25.2
    - [x] Check nginx is running `systemctl status nginx.service`